### PR TITLE
Add Gemini debug step and endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,10 +55,18 @@ jobs:
       working-directory: functions
       run: npm install
 
+    - name: Deploy Cloud Functions
+      run: |
+        echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}" > $HOME/firebase.json
+        npm install -g firebase-tools
+        export GOOGLE_APPLICATION_CREDENTIALS=$HOME/firebase.json
+        firebase deploy --only functions --project my-smart-shopper-e0c23 --force --non-interactive
+      env:
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
     - name: Deploy to Firebase (Preview or Production)
       uses: FirebaseExtended/action-hosting-deploy@v0
       with:
-        repoToken: "${{ secrets.GITHUB_TOKEN }}"
         firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
         projectId: my-smart-shopper-e0c23
         channelId: >-
@@ -70,3 +78,12 @@ jobs:
         entryPoint: .
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+    - name: Debug Gemini response
+      run: |
+        echo "🧠 Testing Gemini endpoint..."
+        RESPONSE=$(curl --silent --show-error --fail -X POST "https://${{ secrets.FIREBASE_PROJECT_ID }}--${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('preview-{0}', github.run_number) }}.web.app/api/gemini" \
+          -H "Content-Type: application/json" \
+          -d '{"prompt": "test"}')
+        echo "🔁 Gemini response:"
+        echo "$RESPONSE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,11 +55,17 @@ jobs:
       working-directory: functions
       run: npm install
 
+    - name: Set up gcloud
+      uses: google-github-actions/setup-gcloud@v1
+
+    - name: Authenticate with service account
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
     - name: Deploy Cloud Functions
       run: |
-        echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}" > $HOME/firebase.json
         npm install -g firebase-tools
-        export GOOGLE_APPLICATION_CREDENTIALS=$HOME/firebase.json
         firebase deploy --only functions --project my-smart-shopper-e0c23 --force --non-interactive
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,10 @@ jobs:
       working-directory: functions
       run: npm install
 
+    - name: Create functions env file
+      run: |
+        echo "GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}" > functions/.env
+
     - name: Authenticate with service account
       uses: google-github-actions/auth@v2
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,13 +55,16 @@ jobs:
       working-directory: functions
       run: npm install
 
-    - name: Set up gcloud
-      uses: google-github-actions/setup-gcloud@v1
-
     - name: Authenticate with service account
       uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        export_environment_variables: true
+
+    - name: Set up gcloud
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: my-smart-shopper-e0c23
 
     - name: Deploy Cloud Functions
       run: |

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Access the app at `http://localhost:5173`.
 
 Feel free to open issues or submit PRs for enhancements or fixes.
 
+## 🚑 Deployment Troubleshooting
+
+If your GitHub Actions deployment fails with errors such as `Permission denied to get service [cloudfunctions.googleapis.com]`, make sure the Cloud Functions API is enabled in your Firebase project and that the service account used in the workflow has permission to deploy functions (e.g. `Cloud Functions Admin` and `Service Usage Consumer`).
+
 ## 📄 License
 
 This project is open-source under the MIT License.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ VITE_FIREBASE_APP_ID="YOUR_FIREBASE_APP_ID"
 # VITE_FIREBASE_MEASUREMENT_ID="YOUR_FIREBASE_MEASUREMENT_ID" # Optional
 ```
 
+For server-side calls to the Gemini API, create a `functions/.env` file:
+
+```bash
+GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
+```
+
 ### 5. Run the Application
 
 ```bash

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "functions": {
+    "source": "functions"
+  },
   "hosting": {
     "public": "dist",
     "ignore": [

--- a/firebase.json
+++ b/firebase.json
@@ -19,6 +19,10 @@
         "function": "gemini"
       },
       {
+        "source": "/api/correctTypos",
+        "function": "correctTypos"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/firebase.json
+++ b/firebase.json
@@ -10,6 +10,14 @@
       {
         "source": "/autoMapItems",
         "function": "autoMapItems"
+      },
+      {
+        "source": "/api/gemini",
+        "function": "gemini"
+      },
+      {
+        "source": "**",
+        "destination": "/index.html"
       }
     ]
   }

--- a/functions/index.js
+++ b/functions/index.js
@@ -54,7 +54,19 @@ async function geminiHandler(req, res) {
     );
 
     const result = await response.json();
-    res.status(200).json(result);
+
+    let parsed = null;
+    const text = result?.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (typeof text === "string") {
+      try {
+        parsed = JSON.parse(text);
+    } catch {
+        // return raw text if it isn't valid JSON
+        parsed = text;
+      }
+    }
+
+    res.status(200).json(parsed ?? result);
   } catch (error) {
     console.error("Gemini API error:", error);
     res.status(500).json({ error: "Gemini API call failed" });
@@ -96,7 +108,18 @@ async function typoHandler(req, res) {
       }
     );
     const result = await response.json();
-    res.status(200).json(result);
+
+    let parsed = null;
+    const text = result?.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (typeof text === "string") {
+      try {
+        parsed = JSON.parse(text);
+    } catch {
+        parsed = text;
+      }
+    }
+
+    res.status(200).json(parsed ?? result);
   } catch (error) {
     console.error("Gemini typo API error:", error);
     res.status(500).json({ error: "Gemini API call failed" });

--- a/functions/index.js
+++ b/functions/index.js
@@ -21,6 +21,10 @@ async function geminiHandler(req, res) {
 
   try {
     const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+    if (!GEMINI_API_KEY) {
+      console.error("GEMINI_API_KEY not set");
+      return res.status(500).json({ error: "Missing Gemini API key" });
+    }
     const payload = {
       contents: [
         {
@@ -89,6 +93,10 @@ async function typoHandler(req, res) {
   }
   try {
     const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+    if (!GEMINI_API_KEY) {
+      console.error("GEMINI_API_KEY not set");
+      return res.status(500).json({ error: "Missing Gemini API key" });
+    }
     const prompt = `Correct spelling mistakes in the following grocery items and return a JSON array of corrected strings. Items: ${items.join(', ')}`;
     const payload = {
       contents: [

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,18 +15,37 @@ async function geminiHandler(req, res) {
 
   try {
     const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        contents: [
-          {
-            role: "user",
-            parts: [{ text: prompt }]
+    const payload = {
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: prompt }]
+        }
+      ],
+      generationConfig: {
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: "ARRAY",
+          items: {
+            type: "OBJECT",
+            properties: {
+              item: { type: "STRING" },
+              section: { type: "STRING" }
+            },
+            propertyOrdering: ["item", "section"]
           }
-        ]
-      })
-    });
+        }
+      }
+    };
+
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      }
+    );
 
     const result = await response.json();
     res.status(200).json(result);

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,10 +1,12 @@
-// Backend endpoint to securely access Gemini API: 
+/* eslint-env node, commonjs */
+/* global require, exports, process */
+// Backend endpoint to securely access Gemini API:
 // secure Gemini proxy. Only backend sees the API key
 
 const functions = require("firebase-functions");
 const fetch = require("node-fetch");
 
-exports.autoMapItems = functions.https.onRequest(async (req, res) => {
+async function geminiHandler(req, res) {
   const { prompt } = req.body;
 
   if (!prompt) {
@@ -32,4 +34,7 @@ exports.autoMapItems = functions.https.onRequest(async (req, res) => {
     console.error("Gemini API error:", error);
     res.status(500).json({ error: "Gemini API call failed" });
   }
-});
+}
+
+exports.autoMapItems = functions.https.onRequest(geminiHandler);
+exports.gemini = functions.https.onRequest(geminiHandler);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -535,25 +535,6 @@ function App() {
 Items:
 ${rawShoppingList.join('\n')}`;
 
-      const chatHistory = [{ role: "user", parts: [{ text: prompt }] }];
-      const payload = {
-        contents: chatHistory,
-        generationConfig: {
-          responseMimeType: "application/json",
-          responseSchema: {
-            type: "ARRAY",
-            items: {
-              type: "OBJECT",
-              properties: {
-                "item": { "type": "STRING" },
-                "section": { "type": "STRING" }
-              },
-              "propertyOrdering": ["item", "section"]
-            }
-          }
-        }
-      };
-
       const response = await fetch("/autoMapItems", {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- add debug step to GitHub workflow to call `/api/gemini`
- expose new `gemini` function and rewrite route
- deploy Cloud Functions via GitHub Actions
- add SPA fallback rewrite for Firebase Hosting
- use preview URL for Gemini debug step

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844064ae144832990a116981d8475f1