### PR TITLE
Fix deployment by specifying live channel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,8 @@ jobs:
         firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         projectId: my-smart-shopper-e0c23
         entryPoint: .
-        channelId: ${{ github.event_name == 'pull_request' && 'pr-' + github.event.pull_request.number || 'preview-' + github.run_number }}
+        channelId: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('preview-{0}', github.run_number) }}
+        target: live
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
@@ -69,6 +70,7 @@ jobs:
         projectId: my-smart-shopper-e0c23
         entryPoint: .
         channelId: live
+        target: live
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         projectId: my-smart-shopper-e0c23
         entryPoint: .
-        channelId: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('preview-{0}', github.run_number) }}
+        channelId: ${{ github.event_name == 'pull_request' && 'pr-' + github.event.pull_request.number || 'preview-' + github.run_number }}
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,6 @@ jobs:
         projectId: my-smart-shopper-e0c23
         entryPoint: .
         channelId: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('preview-{0}', github.run_number) }}
-        target: live
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
@@ -70,7 +69,6 @@ jobs:
         projectId: my-smart-shopper-e0c23
         entryPoint: .
         channelId: live
-        target: live
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,8 @@ jobs:
         firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         projectId: my-smart-shopper-e0c23
         entryPoint: .
+        channelId: live
+        target: live
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 


### PR DESCRIPTION
## Summary
- specify `channelId: live` and `target: live` during production deploy

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68498eadd9d883299a732a424fba5528